### PR TITLE
Unify Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ams_dev*
 db.sqlite3
 __pycache__
 .idea
+secret*

--- a/ams/settings/base.py
+++ b/ams/settings/base.py
@@ -12,7 +12,10 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+
 from django.core.exceptions import ImproperlyConfigured
+
+from secret.secret import *
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 #BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -30,7 +33,8 @@ def get_env_variable(var_name):
         error_msg = "Set the %s environment variable" % var_name
         raise ImproperlyConfigured(error_msg)
  
-SECRET_KEY = get_env_variable('SECRET_KEY')
+# SECRET_KEY = get_env_variable('SECRET_KEY')
+SECRET_KEY = SECRET_KEY
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # :) Taken care off
@@ -47,6 +51,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'attendance',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ams.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ams.settings.development")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
This is meant to make all configurations of settings uniform across all future branches from develop, in order to avoid unnecessary merge conflicts.
